### PR TITLE
Adapt to the latest AdMob API

### DIFF
--- a/nativetemplates/GADTTemplateView.h
+++ b/nativetemplates/GADTTemplateView.h
@@ -84,7 +84,7 @@ extern GADTNativeTemplateStyleKey const GADTNativeTemplateStyleKeyCornerRadius;
 
 /// The super class for every template object.
 /// This class has the majority of all layout and styling logic.
-@interface GADTTemplateView : GADUnifiedNativeAdView
+@interface GADTTemplateView : GADNativeAdView
 @property(nonatomic, copy) NSDictionary<GADTNativeTemplateStyleKey, NSObject*>* styles;
 @property(weak) IBOutlet UILabel* primaryTextView;
 @property(weak) IBOutlet UILabel* secondaryTextView;

--- a/nativetemplates/GADTTemplateView.m
+++ b/nativetemplates/GADTTemplateView.m
@@ -203,7 +203,7 @@ static NSString* const GADTBlue = @"#5C84F0";
   [self applyStyles];
 }
 
-- (void)setNativeAd:(GADUnifiedNativeAd*)nativeAd {
+- (void)setNativeAd:(GADNativeAd*)nativeAd {
   [super setNativeAd:nativeAd];
   self.headlineView = _primaryTextView;
   NSString* adBody = nativeAd.body;


### PR DESCRIPTION
When we upgraded AdMob SDK to version 8.0.0+, GADUnifiedNativeAdView has been renamed to GADNativeAdView, this change was made to adapt Google Ads Mobile iOS Native Templates to the latest AdMob SDK 8.0.0+.

Fixed issues: #4 #6 